### PR TITLE
Escape pipe char “|” in README.md table

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ The default cutter in Werft expects the following syntax:
 
 | Code | Command | Description |
 | --------- | ----- | ----------- |
-| `[someID|PHASE] Some description here` | Enter new phase | Enters into a new phase identified by `someID` and described by `Some description here`. All output in this phase that does not explicitely name a slice will use `someID` as slice.
+| `[someID\|PHASE] Some description here` | Enter new phase | Enters into a new phase identified by `someID` and described by `Some description here`. All output in this phase that does not explicitely name a slice will use `someID` as slice.
 | `[someID] Arbitrary output` | Log to a slice | Logs `Arbitrary output` and marks it as part of the `someID` slice.
-| `[someID|DONE]` | Finish a slice | Marks the `someID` slice as done. No more output is expected from this slice in this phase.
-| `[someID|FAIL] Reason` | Fail a slice | Marks the `someID` slice as failed becuase of `Reason`. No more output is expected from this slice in this phase. Failing a slice does not automatically fail the job.
-| `[type|RESULT] content` | Publish a result | Publishes `content` as result of type `type` 
+| `[someID\|DONE]` | Finish a slice | Marks the `someID` slice as done. No more output is expected from this slice in this phase.
+| `[someID\|FAIL] Reason` | Fail a slice | Marks the `someID` slice as failed becuase of `Reason`. No more output is expected from this slice in this phase. Failing a slice does not automatically fail the job.
+| `[type\|RESULT] content` | Publish a result | Publishes `content` as result of type `type` 
 
 > **Tip**: You can produce this kind of log output using the Werft CLI: `werft log`
 


### PR DESCRIPTION
Since different Markdown interpreters handle this differently, it is necessary for GitHub to mask the pipe character when using in tables even in code blocks.

**Before:**

![image](https://user-images.githubusercontent.com/24960040/73178311-479de100-4111-11ea-9cc1-30d65d9d28bf.png)



**After:**

![image](https://user-images.githubusercontent.com/24960040/73178334-52f10c80-4111-11ea-89ca-a5c9bc5cf019.png)
