### PR TITLE
[github] Fix typo in reported Werft status

### DIFF
--- a/pkg/werft/github.go
+++ b/pkg/werft/github.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	werftGithubContext       = "continunous-integration/werft"
-	werftResultGithubContext = "continunous-integration/werft/result"
+	werftGithubContext       = "continuous-integration/werft"
+	werftResultGithubContext = "continuous-integration/werft/result"
 
 	// annotationStatusUpdate is set on jobs whoose status needs to be updated on GitHub.
 	// This is set only on jobs created through GitHub events.


### PR DESCRIPTION
I just noticed a typo in the Status/Checks that Werft reports in my Pull Request:

<img width="681" alt="Screenshot 2020-01-28 at 15 56 11" src="https://user-images.githubusercontent.com/599268/73275074-e7796e80-41e6-11ea-903b-dc3aa60e01a5.png">

- continunous → continuous