### PR TITLE
[webui] Add job name to page title

### DIFF
--- a/pkg/webui/src/JobView.tsx
+++ b/pkg/webui/src/JobView.tsx
@@ -106,6 +106,8 @@ class JobViewImpl extends React.Component<JobViewProps, JobViewState> {
             Notification.requestPermission();
         }
 
+        document.title = `werft - ${this.props.jobName}`;
+
         const req = new GetJobRequest();
         req.setName(this.props.jobName);
         try {


### PR DESCRIPTION
Adds the job name to the page title:
![image](https://user-images.githubusercontent.com/3210701/73441585-828f5700-4353-11ea-9568-9e535bb35e5d.png)


Fixes csweichel/werft#44