### PR TITLE
[web-ui] Render HTML correctly when showing raw logs

### DIFF
--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -15,5 +15,6 @@ pod:
         echo "[url|RESULT] https://github.com/32leaves/tree/{{ .Repository.Ref }} this branch on Github"
         echo "hello world"
         echo "some more regular logging"
+        echo "{{ .Annotations.msg }}"
         echo "[docker|RESULT] csweichel/werft:{{ .Name }} this version's docker image"
         echo "[docker|RESULT] csweichel/werft-utils:{{ .Name }} this versions utility image"

--- a/pkg/webui/src/components/LogView.tsx
+++ b/pkg/webui/src/components/LogView.tsx
@@ -170,7 +170,7 @@ class LogViewImpl extends React.Component<LogViewProps, LogViewState> {
                 </Grid>
             </Grid>
             <StickyScroll>
-                <div className="term-container" style={{width:"100%"}} dangerouslySetInnerHTML={{__html: this.getRawLogs()}} />
+                <div className="term-container" style={{width:"100%"}}>{this.getRawLogs()}</div>
             </StickyScroll>
         </React.Fragment>
     }

--- a/pkg/werft/werft.go
+++ b/pkg/werft/werft.go
@@ -482,9 +482,9 @@ func (srv *Service) RunJob(ctx context.Context, name string, metadata v1.JobMeta
 		return nil, xerrors.Errorf("cannot handle job for %s: no podspec present", name)
 	}
 
-	nodePath := filepath.Join(srv.Config.WorkspaceNodePathPrefix, name)
 	wsVolume := "werft-workspace"
-	if nodePath != "" {
+	if srv.Config.WorkspaceNodePathPrefix != "" {
+		nodePath := filepath.Join(srv.Config.WorkspaceNodePathPrefix, name)
 		httype := corev1.HostPathDirectoryOrCreate
 		podspec.Volumes = append(podspec.Volumes, corev1.Volume{
 			Name: wsVolume,


### PR DESCRIPTION
## How to test
1. Run `go run client.go run github -j .werft/debug.yaml -a msg="<test />" -f`
2. Go to the raw logs page of the job. Run `echo $(gp url 8080)/job/werft-debug-csweichel-webui-escaping-issue-54.0/raw` to find that URL
3. Observe how `<test />` is shown correctly in the raw logs

Fixes csweichel/werft#54