### PR TITLE
Make GitHub link even more prominent

### DIFF
--- a/page/src/assets/scss/components/_section.scss
+++ b/page/src/assets/scss/components/_section.scss
@@ -55,8 +55,12 @@
             background: #9C63AB;
             margin-right: 8px;
 
-            &:hover{
-                background: #815DA1;
+            &:hover {
+                background: #A76AB8;
+            }
+
+            &:active {
+                background: #C267B8;
             }
         }
 	}

--- a/page/src/assets/scss/components/_section.scss
+++ b/page/src/assets/scss/components/_section.scss
@@ -50,6 +50,15 @@
 				}
 			}
 		}
+
+        .primary {
+            background: #9C63AB;
+            margin-right: 8px;
+
+            &:hover{
+                background: #815DA1;
+            }
+        }
 	}
 
 	footer {

--- a/page/src/components/Header.tsx
+++ b/page/src/components/Header.tsx
@@ -7,6 +7,8 @@ const Header: React.SFC<{}> = (props) => (
         <span className="logo"><img src={logo} alt="" height="200px" /></span>
         <h1>Just Kubernetes Native CI</h1>
         <p>Because your job is hard enough.</p>
+        <a class="button primary" href="#getting-started">Getting started</a>
+        <a class="button icon solid fa-github source" target="_blank" href="https://github.com/csweichel/werft">View on GitHub</a>
     </header>
 )
 

--- a/page/src/components/Nav.tsx
+++ b/page/src/components/Nav.tsx
@@ -24,9 +24,6 @@ const Nav: React.SFC<NavProps> = React.forwardRef((props, ref: Ref<HTMLElement>)
                     <a href="#getting-started">Getting Started</a>
                 </Scroll>
             </li>
-            <li>
-                <a href="https://github.com/csweichel/werft">GitHub</a>
-            </li>
         </Scrollspy>
     </nav>
 ))


### PR DESCRIPTION
## What does this PR do?

This will make the GitHub link even more prominent and introduce a primary action button in the header section, following the design language used by the existing theme.

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/97791336-04115f80-1bda-11eb-826e-b3e27bd281c7.png) | ![image](https://user-images.githubusercontent.com/120486/97791340-0bd10400-1bda-11eb-9c83-83ac4e2fd227.png) |


