### PR TITLE
Add job and log garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The helm chart's `values.yaml` is the reference for chart's configuration surfac
 | `config.baseURL` | URL of your Werft installatin | `https://demo.werft.dev` |
 | `config.timeouts.preperation` | Time a job can take to initialize | `10m` |
 | `config.timeouts.total` | Total time a job can take | `60m` |
+| `config.gcOlderThan` | Garbage Collect logs and job metadata for jobs older than the configured value | `null` |
 | `image.repository` | Image repository | `csweichel/werft` |
 | `image.tag` | Image tag | `latest` |
 | `image.pullPolicy` | Image pull policy | `Always` |

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b
+	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2
 	golang.org/x/tools v0.1.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.34.0-dev
@@ -70,7 +71,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/pkg/store/postgres/job.go
+++ b/pkg/store/postgres/job.go
@@ -61,6 +61,16 @@ func (s *JobStore) RegisterPrometheusMetrics(reg prometheus.Registerer) {
 	)
 }
 
+// GarbageCollect removes all job entries older than the specified duration
+func (s *JobStore) GarbageCollect(olderThan time.Duration) error {
+	_, err := s.DB.Query(`
+		DELETE FROM job_status 
+		WHERE created <= $1
+		  AND phase = 'done'
+	`, time.Now().Add(-olderThan).Unix())
+	return err
+}
+
 // Store stores job information in the store.
 func (s *JobStore) Store(ctx context.Context, job v1.JobStatus) error {
 	defer func(start time.Time) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	v1 "github.com/csweichel/werft/pkg/api/v1"
 )
@@ -32,6 +33,9 @@ type Logs interface {
 	// Callers are supposed to close the reader once done.
 	// Reading from logs currently being written is supported.
 	Read(id string) (io.ReadCloser, error)
+
+	// GarbageCollect removes all logs older than the given duration.
+	GarbageCollect(olderThan time.Duration) error
 }
 
 // Jobs provides access to past jobs
@@ -54,6 +58,9 @@ type Jobs interface {
 	// Searches for jobs based on their annotations. If filter is empty no filter is applied.
 	// If limit is 0, no limit is applied.
 	Find(ctx context.Context, filter []*v1.FilterExpression, order []*v1.OrderExpression, start, limit int) (slice []v1.JobStatus, total int, err error)
+
+	// GarbageCollect removes all logs older than the given duration.
+	GarbageCollect(olderThan time.Duration) error
 }
 
 // NumberGroup enables to atomic generation and storage of numbers.

--- a/plugins/integration-example/go.mod
+++ b/plugins/integration-example/go.mod
@@ -8,3 +8,15 @@ require (
 	github.com/csweichel/werft v0.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.8.1
 )
+
+require (
+	github.com/golang/protobuf v1.4.3 // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
+	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.34.0-dev // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)

--- a/testdata/in-gitpod-config.yaml
+++ b/testdata/in-gitpod-config.yaml
@@ -1,6 +1,7 @@
 werft:
   baseURL: https://werft.dev
   workspaceNodePathPrefix: "/mnt/disks/ssd0/builds"
+  gcOlderThan: "10m"
   cleanupJobSpec:
     terminationGracePeriodSeconds: 10
 service:


### PR DESCRIPTION
This PR adds job and log garbage collection. When enabled in the configuration, it deletes all jobs and logs older than the configured duration.

This feature is not enabled by default and must be configured to become active, for example:
https://github.com/csweichel/werft/blob/eac41ba64b0d36d6b220a32e0c9380839aa9a714/testdata/in-gitpod-config.yaml#L4

fixes #121 