### PR TITLE
PROPOSAL: [github] Keep pulling annotations from non-main commits

### DIFF
--- a/plugins/github-repo/pkg/provider/provider.go
+++ b/plugins/github-repo/pkg/provider/provider.go
@@ -89,6 +89,13 @@ func (s *GithubRepoServer) GetRemoteAnnotations(ctx context.Context, req *common
 	}
 
 	res := make(map[string]string)
+	if repo.Ref != fmt.Sprintf("refs/heads/%s", repo.DefaultBranch) && commit.Commit != nil {
+		atns := parseAnnotations(commit.Commit.GetMessage())
+		for k, v := range atns {
+			res[k] = v
+		}
+	}
+
 	prs, _, err := s.Client.PullRequests.ListPullRequestsWithCommit(ctx, repo.Owner, repo.Repo, commit.GetSHA(), &github.PullRequestListOptions{
 		State: "open",
 		Sort:  "created",


### PR DESCRIPTION
In https://github.com/csweichel/werft/commit/d5e1218fcdecca5c6a09fcb6b00b81f34b5adc03 you removed the support of annotations in commits. To address my concern I raised in https://github.com/gitpod-io/ops/issues/965#issuecomment-1027781646, I would propose a solution like the following that ignores commit annotations for the main branch only.