### PR TITLE
Adapt CLI to validate server config

### DIFF
--- a/cmd/client/validate-config.go
+++ b/cmd/client/validate-config.go
@@ -1,0 +1,49 @@
+package cmd
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/spf13/cobra"
+	servercmd "github.com/csweichel/werft/cmd/server"
+)
+
+// validateConfigCmd validates a Werft config file.
+var validateConfigCmd = &cobra.Command{
+	Use:   "validate-config",
+	Short: "Validates a YAML config file used to start a Werft server.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fc, err := ioutil.ReadFile(args[0])
+		if err != nil {
+			log.Fatalf("Could not read %v", args[0])
+		}
+
+		_, err = servercmd.LoadConfig(fc)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateConfigCmd)
+}

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -59,7 +59,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
-	"gopkg.in/yaml.v3"
+	yamlv2 "gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -79,8 +79,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		var cfg Config
-		err = yaml.Unmarshal(fc, &cfg)
+		cfg, err := LoadConfig(fc)
 		if err != nil {
 			return err
 		}
@@ -500,6 +499,16 @@ func init() {
 	runCmd.Flags().String("debug-webui-proxy", "", "proxies the web UI to this address")
 	runCmd.Flags().Bool("verbose", false, "enable verbose debug output")
 }
+
+func LoadConfig(content []byte) (*Config, error) {
+	cfg := &Config{}
+	err := yamlv2.UnmarshalStrict(content, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
 
 // Config configures the werft server
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/tools v0.1.5
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.36.1
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
@@ -85,7 +86,6 @@ require (
 	google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/testdata/example-config.yaml
+++ b/testdata/example-config.yaml
@@ -13,8 +13,3 @@ executor:
 storage:
   logsPath: "/tmp/logs"
   jobsConnectionString: dbname=werft user=postgres connect_timeout=5 sslmode=disable
-github:
-  webhookSecret: foobar
-  privateKeyPath: testdata/example-app.pem
-  appID: 48144
-  installationID: 5647067

--- a/testdata/invalid-config.yaml
+++ b/testdata/invalid-config.yaml
@@ -1,0 +1,2 @@
+werft:
+  thisFieldDontExist: testing


### PR DESCRIPTION
## Description

Unfortunately, I've lost count of how many times we had to roll back Werft upgrades because we failed to specify a valid werft configuration.

This PR is adding a new command to Werft CLI so we can validate a config file before updating a Werft server.

## Alternative approaches

#### Dedicated `config` package used by both CLI and Server

I've noticed that we have a `Config` type under `pkg/werft.go` and also `cmd/server/run.go`. I wanted to merge those two into a single one into a dedicated package, so it becomes easier to make `LoadConfig` testable.

I gave up after 30m trying because go modules are too hard to understand 😅 
