### PR TITLE
cleanup job also clean hidden files

### DIFF
--- a/pkg/werft/werft.go
+++ b/pkg/werft/werft.go
@@ -625,7 +625,7 @@ func (srv *Service) cleanupJobWorkspace(s *v1.JobStatus) {
 	podspec.Containers = append(podspec.Containers, corev1.Container{
 		Name:       "cleanup",
 		Image:      "alpine:latest",
-		Command:    []string{"sh", "-c", "rm -rf *"},
+		Command:    []string{"sh", "-c", "rm -rf .* * 2>&-"},
 		WorkingDir: "/workspace",
 		VolumeMounts: []corev1.VolumeMount{
 			{


### PR DESCRIPTION
cleanup job also clean hidden files

some hidden files like .gradle is too large, this can consume disk resources too quickly

![image](https://user-images.githubusercontent.com/8299500/164478342-cb465863-d608-4ce1-a0c4-9de7049bd93e.png)
