### PR TITLE
Add github-auth to the plugins BUILD.yaml

### DIFF
--- a/plugins/BUILD.yaml
+++ b/plugins/BUILD.yaml
@@ -3,6 +3,7 @@ packages:
     type: generic
     deps:
       - plugins/cron:app
+      - plugins/github-auth:app
       - plugins/github-repo:app
       - plugins/github-integration:app
       - plugins/integration-example:app


### PR DESCRIPTION
# Description
Adds github-auth to the plugins BUILD.yaml which will bring it into the container image

# Issue
Fixes #141 