### PR TITLE
Fix multiple jobs running on PullRequest event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 **/rice-box.go
+.idea

--- a/plugins/github-integration/fixtures/processPullRequestEvent_noRerun.json
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_noRerun.json
@@ -34,7 +34,7 @@
                 "type": "User",
                 "site_admin": false
             },
-            "body": "- [x] /werft with-preview",
+            "body": "- [ ] /werft with-preview",
             "created_at": "2021-07-06T13:03:07Z",
             "updated_at": "2022-06-01T19:37:58Z",
             "closed_at": null,
@@ -354,7 +354,7 @@
         },
         "changes": {
             "body": {
-                "from": "- [x] /werft with-preview"
+                "from": "- [ ] /werft with-preview"
             }
         },
         "repository": {
@@ -481,6 +481,16 @@
         }
     },
     "ListResponse": [
+        {
+            "Metadata": {
+                "Repository": {
+                    "Revision": "we're-skipping-this-one"
+                },
+                "Annotations": [
+                    {"Key": "and-this", "Value": "doesn't-matter"}
+                ]
+            }
+        },
         {
             "Metadata": {
                 "Repository": {

--- a/plugins/github-integration/fixtures/processPullRequestEvent_rerun.golden
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_rerun.golden
@@ -1,1 +1,26 @@
-{"metadata":{"owner":"csweichel","repository":{"host":"github.com","owner":"csweichel","repo":"test-repo","ref":"refs/heads/cannot-init","revision":"eed6dfe4dad7e3519acf52679b9880c5d2a2afbf","defaultBranch":"master"},"trigger":"TRIGGER_MANUAL","annotations":[{"key":"updateGitHubStatus","value":"csweichel/test-repo"},{"key":"with-preview"}]},"spec":{"jobPath":""}}
+{
+  "metadata": {
+    "owner": "csweichel",
+    "repository": {
+      "host": "github.com",
+      "owner": "csweichel",
+      "repo": "test-repo",
+      "ref": "refs/heads/cannot-init",
+      "revision": "eed6dfe4dad7e3519acf52679b9880c5d2a2afbf",
+      "defaultBranch": "master"
+    },
+    "trigger": "TRIGGER_MANUAL",
+    "annotations": [
+      {
+        "key": "updateGitHubStatus",
+        "value": "csweichel/test-repo"
+      },
+      {
+        "key": "with-preview"
+      }
+    ]
+  },
+  "spec": {
+    "jobPath": ""
+  }
+}

--- a/plugins/github-integration/fixtures/processPullRequestEvent_rerun.json
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_rerun.json
@@ -485,10 +485,7 @@
             "Metadata": {
                 "Repository": {
                     "Revision": "eed6dfe4dad7e3519acf52679b9880c5d2a2afbf"
-                },
-                "Annotations": [
-                    {"Key": "with-preview", "Value": ""}   
-                ]
+                }
             }
         }
     ]

--- a/plugins/github-integration/main_test.go
+++ b/plugins/github-integration/main_test.go
@@ -257,7 +257,7 @@ func TestProcessPushEvent(t *testing.T) {
 	}
 }
 
-func TestProcessPullRequestEvent(t *testing.T) {
+func TestProcessPullRequestEditedEvent(t *testing.T) {
 	type Fixture struct {
 		Event        *github.PullRequestEvent
 		ListResponse []*v1.JobStatus
@@ -319,7 +319,7 @@ func TestProcessPullRequestEvent(t *testing.T) {
 			if fixture.Event == nil {
 				t.Fatal("broken fixture: no event")
 			}
-			plg.processPullRequestEvent(context.Background(), fixture.Event)
+			plg.processPullRequestEditedEvent(context.Background(), fixture.Event)
 
 			var expectation *v1.StartJobRequest2
 			goldenFN := strings.TrimSuffix(fn, filepath.Ext(fn)) + ".golden"
@@ -349,7 +349,7 @@ func TestProcessPullRequestEvent(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(expectation, startReq); diff != "" {
-				t.Errorf("processPullRequestEvent() mismatch (-want +got):\n%s", diff)
+				t.Errorf("processPullRequestEditedEvent() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes: https://github.com/csweichel/werft/issues/154

There were 2 reasons why multiple jobs were getting processed:
* The implementation processing the PR event was wrong. It was doing the opposite of what we want it to do - i.e. it was triggering a job when the annotations were the same (that's a big reason why I don't like double negatives like `noReRun` - it makes it confusing).
* There are multiple `pull_request` events - see one of the comments. 

This PR should fix those issues - it simplifies the logic a bit and only processes the relevant event type. Also fixes the tests. 