### PR TITLE
Fix job trigger on every PR edit

### DIFF
--- a/plugins/github-integration/fixtures/processPullRequestEvent_noMD.golden
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_noMD.golden
@@ -1,1 +1,23 @@
-{"metadata":{"owner":"csweichel","repository":{"host":"github.com","owner":"csweichel","repo":"test-repo","ref":"refs/heads/cannot-init","revision":"eed6dfe4dad7e3519acf52679b9880c5d2a2afbf","defaultBranch":"master"},"trigger":"TRIGGER_MANUAL","annotations":[{"key":"updateGitHubStatus","value":"csweichel/test-repo"}]},"spec":{"jobPath":""}}
+{
+  "metadata": {
+    "owner": "csweichel",
+    "repository": {
+      "host": "github.com",
+      "owner": "csweichel",
+      "repo": "test-repo",
+      "ref": "refs/heads/cannot-init",
+      "revision": "eed6dfe4dad7e3519acf52679b9880c5d2a2afbf",
+      "defaultBranch": "master"
+    },
+    "trigger": "TRIGGER_MANUAL",
+    "annotations": [
+      {
+        "key": "updateGitHubStatus",
+        "value": "csweichel/test-repo"
+      }
+    ]
+  },
+  "spec": {
+    "jobPath": ""
+  }
+}

--- a/plugins/github-integration/fixtures/processPullRequestEvent_noMD.json
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_noMD.json
@@ -354,7 +354,7 @@
         },
         "changes": {
             "body": {
-                "from": "- [ ] /werft with-preview"
+                "from": "- [x] /werft with-preview"
             }
         },
         "repository": {

--- a/plugins/github-integration/fixtures/processPullRequestEvent_rerun.json
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_rerun.json
@@ -354,7 +354,7 @@
         },
         "changes": {
             "body": {
-                "from": "- [x] /werft with-preview"
+                "from": "- [ ] /werft with-preview"
             }
         },
         "repository": {

--- a/plugins/github-integration/fixtures/processPullRequestEvent_withMD.golden
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_withMD.golden
@@ -1,1 +1,26 @@
-{"metadata":{"owner":"csweichel","repository":{"host":"github.com","owner":"csweichel","repo":"test-repo","ref":"refs/heads/cannot-init","revision":"eed6dfe4dad7e3519acf52679b9880c5d2a2afbf","defaultBranch":"master"},"trigger":"TRIGGER_MANUAL","annotations":[{"key":"updateGitHubStatus","value":"csweichel/test-repo"},{"key":"with-preview"}]},"spec":{"jobPath":""}}
+{
+  "metadata": {
+    "owner": "csweichel",
+    "repository": {
+      "host": "github.com",
+      "owner": "csweichel",
+      "repo": "test-repo",
+      "ref": "refs/heads/cannot-init",
+      "revision": "eed6dfe4dad7e3519acf52679b9880c5d2a2afbf",
+      "defaultBranch": "master"
+    },
+    "trigger": "TRIGGER_MANUAL",
+    "annotations": [
+      {
+        "key": "updateGitHubStatus",
+        "value": "csweichel/test-repo"
+      },
+      {
+        "key": "with-preview"
+      }
+    ]
+  },
+  "spec": {
+    "jobPath": ""
+  }
+}

--- a/plugins/github-integration/fixtures/processPullRequestEvent_withMD.json
+++ b/plugins/github-integration/fixtures/processPullRequestEvent_withMD.json
@@ -354,7 +354,7 @@
         },
         "changes": {
             "body": {
-                "from": "- [x] /werft with-preview"
+                "from": "- [ ] /werft with-preview"
             }
         },
         "repository": {
@@ -479,5 +479,14 @@
             "id": 5647067,
             "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uNTY0NzA2Nw=="
         }
-    }
+    },
+    "ListResponse": [
+        {
+            "Metadata": {
+                "Repository": {
+                    "Revision": "eed6dfe4dad7e3519acf52679b9880c5d2a2afbf"
+                }
+            }
+        }
+    ]
 }

--- a/plugins/github-repo/pkg/provider/provider.go
+++ b/plugins/github-repo/pkg/provider/provider.go
@@ -113,7 +113,7 @@ func (s *GithubRepoServer) GetRemoteAnnotations(ctx context.Context, req *common
 	}, nil
 }
 
-// pareseAnnotations parses one annotation per line in the form of "/werft <key>(=<value>)?".
+// ParseAnnotations parses one annotation per line in the form of "/werft <key>(=<value>)?".
 // Any line not matching this format is silently ignored.
 func ParseAnnotations(message string) (res map[string]string) {
 	scanner := bufio.NewScanner(bytes.NewReader([]byte(message)))


### PR DESCRIPTION
- Fixes a case where the job would always get triggered when a PR is edited - the reason being always having a mismatch between the annotations, since one of them is added practically always, but not at the stage where we process the PR event.
- Also now events are handled only if the annotations in the PR got changed when the PR was edited.