### PR TITLE
Update section description overflow wrap in logs

### DIFF
--- a/pkg/webui/src/components/LogView.tsx
+++ b/pkg/webui/src/components/LogView.tsx
@@ -33,6 +33,7 @@ export const styles = (theme: Theme) =>
         },
         sectionDesc: {
             flex: 1,
+            overflowWrap: 'anywhere'
         },
         sectionLink: {
             alignSelf: 'end',


### PR DESCRIPTION
### What does this MR do and why?

This will add the [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) class on the section description column on the logs, as it causes the screen to overflow horizontally when there are many jobs, making the close button inaccessible without scrolling to the right.

Happens when:
1. Using a small screen like the MacBook's 13" inch screen.
2. Job outputs contain long strings like the `job config` in Gitpod's configuration, see [example job](https://werft.gitpod-dev.com/job/gitpod-build-main.4266).

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-08-12 at 6 26 08 PM" src="https://user-images.githubusercontent.com/120486/184389587-e9cdd6fa-81bc-4b49-aaf3-fc5c2bb9f346.png"> | <img width="1440" alt="Screenshot 2022-08-12 at 6 26 13 PM" src="https://user-images.githubusercontent.com/120486/184389601-be372d0a-9714-428d-b523-36244e8a48a8.png"> |