### PR TITLE
[webui] sort job annotations

### DIFF
--- a/pkg/webui/src/JobView.tsx
+++ b/pkg/webui/src/JobView.tsx
@@ -399,7 +399,7 @@ class JobViewImpl extends React.Component<JobViewProps, JobViewState> {
                 thirdrow = <Toolbar>
                     <Grid container spacing={1} alignItems="center" className={this.props.classes.infobar}>
                         <Grid item xs={12}><Divider light={true} /></Grid>
-                        { job.metadata.annotationsList.map((a, k) => <JobMetadataItemProps key={k} label={a.key}>{a.value}</JobMetadataItemProps>) }
+                        { job.metadata.annotationsList.sort((a, b) => a.key > b.key ? 1 : -1).map((a, k) => <JobMetadataItemProps key={k} label={a.key}>{a.value}</JobMetadataItemProps>) }
                     </Grid>
                 </Toolbar>;
             }


### PR DESCRIPTION
Fixes #165.

This is a quick stab at sorting job annotations; I've not yet stood up a werft test environment to validate this but can run this through the paces shortly if this is deemed worthwhile.