### PR TITLE
[webui] Use `.key` instead of `.keyCode` / `.charCode` for keyboard events

### DIFF
--- a/pkg/webui/src/JobList.tsx
+++ b/pkg/webui/src/JobList.tsx
@@ -300,8 +300,8 @@ class JobListImpl extends React.Component<JobListProps, JobListState> {
     }
 
     protected handleSearchKeyPress(evt: KeyboardEvent) {
-        if (evt.charCode !== 13) {
-            return
+        if (evt.key !== "Enter") {
+            return;
         }
 
         window.location.href = "/jobs/" + (evt.target as HTMLInputElement).value;

--- a/pkg/webui/src/JobView.tsx
+++ b/pkg/webui/src/JobView.tsx
@@ -498,8 +498,8 @@ class JobViewImpl extends React.Component<JobViewProps, JobViewState> {
 }
 
 function returnToJobList(this: Window, evt: KeyboardEvent): any {
-    if (evt.keyCode !== 27) {
-        return
+    if (evt.key !== "Escape") {
+        return;
     }
 
     evt.preventDefault();

--- a/pkg/webui/src/StartJob.tsx
+++ b/pkg/webui/src/StartJob.tsx
@@ -219,8 +219,8 @@ class StartJobImpl extends React.Component<StartJobProps, StartJobState> {
     }
 
     protected handleSearchKeyPress(evt: KeyboardEvent) {
-        if (evt.charCode !== 13) {
-            return
+        if (evt.key !== "Enter") {
+            return;
         }
 
         window.location.href = "/jobs/" + (evt.target as HTMLInputElement).value;


### PR DESCRIPTION
This change removed deprecated ways of looking up a key on the keyboard and instead uses `.key`, which is both not deprecated and human-readable.

From MDN [[1](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode)]:
> Warning: Do not use this property, as it is deprecated. Instead, get the Unicode value of the character using the [key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property.
