### PR TITLE
[cron] using latest revision instead of cache one

### DIFF
--- a/plugins/cron/main.go
+++ b/plugins/cron/main.go
@@ -87,6 +87,7 @@ func (*cronPlugin) Run(ctx context.Context, config interface{}, srv *plugin.Serv
 					},
 					JobPath: spec.Path,
 				}
+				request.Metadata.Repository.Revision = ""
 				entryID, err := c.AddFunc(cronSpec, func() {
 					_, err := srv.StartGitHubJob(ctx, request)
 					if err != nil {
@@ -148,6 +149,7 @@ func (*cronPlugin) Run(ctx context.Context, config interface{}, srv *plugin.Serv
 			},
 			JobPath: task.JobPath,
 		}
+		request.Metadata.Repository.Revision = ""
 		_, err = c.AddFunc(task.Spec, func() {
 			_, err := srv.StartGitHubJob(ctx, request)
 			if err != nil {


### PR DESCRIPTION
in cron job, we use a cached revision, which is not expected, we want use latest of target branch

This PR set revision to empty string, so that it can resolve by start time 

https://github.com/csweichel/werft/blob/0fe8c76a992f76ba5936b4027fe78ed995b53a24/pkg/werft/service.go#L172-L177

https://github.com/csweichel/werft/blob/0fe8c76a992f76ba5936b4027fe78ed995b53a24/plugins/github-repo/pkg/provider/provider.go#L70-L78

https://github.com/csweichel/werft/blob/0fe8c76a992f76ba5936b4027fe78ed995b53a24/pkg/plugin/host/repo.go#L96-L108