### PR TITLE
feat: add support for capital `X` - e.g. `- [X]`

### DIFF
--- a/plugins/github-repo/pkg/provider/provider.go
+++ b/plugins/github-repo/pkg/provider/provider.go
@@ -121,6 +121,7 @@ func ParseAnnotations(message string) (res map[string]string) {
 		line := scanner.Text()
 		line = strings.TrimSpace(line)
 		line = strings.TrimPrefix(line, "- [x]")
+		line = strings.TrimPrefix(line, "- [X]")
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "/werft ") {
 			continue

--- a/plugins/github-repo/pkg/provider/provider_test.go
+++ b/plugins/github-repo/pkg/provider/provider_test.go
@@ -36,6 +36,11 @@ func TestParseAnnotations(t *testing.T) {
 			Expected: map[string]string{"foobar": ""},
 		},
 		{
+			Name:     "werft annotation with checkbox and capital X",
+			Input:    "- [X] /werft foobar",
+			Expected: map[string]string{"foobar": ""},
+		},
+		{
 			Name:     "werft annotation with checkbox",
 			Input:    "- [x]    /werft foobar=value",
 			Expected: map[string]string{"foobar": "value"},


### PR DESCRIPTION
## Description

Currently, it just supports `- [x]` checkbox with small `x` in PR Descriptions. This PR aims to add support for `-[X]` with a test :sparkles: